### PR TITLE
feat: add a DslMarker annotation

### DIFF
--- a/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/DocumentationScope.kt
+++ b/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/DocumentationScope.kt
@@ -12,6 +12,7 @@ import org.springframework.restdocs.snippet.Snippet
  * These extension functions are specific to the test framework (MockMvc, WebTestClient, RestAssured) chosen
  * to generate the documentation.
  */
+@RestDocumentationDslMarker
 interface DocumentationScope {
 
     /**

--- a/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/FieldsScope.kt
+++ b/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/FieldsScope.kt
@@ -5,6 +5,7 @@ import org.springframework.restdocs.payload.FieldDescriptor
 /**
  * Receiver of the extension function used to add field descriptors to fields snippets
  */
+@RestDocumentationDslMarker
 interface FieldsScope {
 
     /**

--- a/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/HeadersScope.kt
+++ b/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/HeadersScope.kt
@@ -5,6 +5,7 @@ import org.springframework.restdocs.headers.HeaderDescriptor
 /**
  * Receiver of the extension function used to add header descriptors to headers snippets
  */
+@RestDocumentationDslMarker
 interface HeadersScope {
 
     /**

--- a/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/LinksScope.kt
+++ b/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/LinksScope.kt
@@ -5,6 +5,7 @@ import org.springframework.restdocs.hypermedia.LinkDescriptor
 /**
  * Receiver of the extension function used to add link descriptors to links snippets
  */
+@RestDocumentationDslMarker
 interface LinksScope {
 
     /**

--- a/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/ParametersScope.kt
+++ b/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/ParametersScope.kt
@@ -5,6 +5,7 @@ import org.springframework.restdocs.request.ParameterDescriptor
 /**
  * Receiver of the extension function used to add parameter descriptors to parameters snippets
  */
+@RestDocumentationDslMarker
 interface ParametersScope {
 
     /**

--- a/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/RequestPartsScope.kt
+++ b/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/RequestPartsScope.kt
@@ -5,6 +5,7 @@ import org.springframework.restdocs.request.RequestPartDescriptor
 /**
  * Receiver of the extension function used to add request part descriptors to request parts snippets
  */
+@RestDocumentationDslMarker
 interface RequestPartsScope {
 
     /**

--- a/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/RestDocumentationDslMarker.kt
+++ b/core/src/main/kotlin/com/ninjasquad/springrestdocskotlin/core/RestDocumentationDslMarker.kt
@@ -1,0 +1,9 @@
+package com.ninjasquad.springrestdocskotlin.core
+
+/**
+ * DSL marker for REST Documentation Kotlin DSL
+ * @author JB Nizet
+ */
+@DslMarker
+annotation class RestDocumentationDslMarker {
+}


### PR DESCRIPTION
This makes sure it's impossible to add responseFields from inside the pathParameters block, for example